### PR TITLE
Secure resource paths

### DIFF
--- a/app/doc/DocRenderer.scala
+++ b/app/doc/DocRenderer.scala
@@ -205,6 +205,9 @@ class DocRenderer(
 
     case Render(path) =>
       val resource = docSources.resolve(path.drop(1)).toFile
-      sender() ! (if (resource.exists()) resource else NotFound(path))
+      sender() ! (if (resource.exists() && resource.getAbsolutePath.startsWith(docSources.toString))
+        resource
+      else
+        NotFound(path))
   }
 }


### PR DESCRIPTION
Ensure that the path being looked up belongs within this context
