### PR TITLE
ConductR-ization

### DIFF
--- a/app/plugins/ConductrPlugin.scala
+++ b/app/plugins/ConductrPlugin.scala
@@ -1,0 +1,20 @@
+package plugins
+
+import com.typesafe.conductr.bundlelib.play.StatusService
+import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import play.api.{ Application, Plugin, Logger }
+import play.api.libs.concurrent.Execution
+
+class ConductrPlugin() extends Plugin {
+  
+  override def onStart() {
+    import Implicits.defaultContext
+    StatusService.signalStartedOrExit()
+    Logger.info("Application has started")
+  }
+
+  override def onStop() {
+    Logger.info("Application shutdown...")
+  }
+
+}

--- a/app/plugins/ConductrPlugin.scala
+++ b/app/plugins/ConductrPlugin.scala
@@ -1,0 +1,20 @@
+package plugins
+
+import com.typesafe.conductr.bundlelib.play.StatusService
+import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import play.api.{ Application, Plugin, Logger }
+import play.api.libs.concurrent.Execution
+
+class ConductrPlugin extends Plugin {
+  
+  override def onStart() {
+    import Implicits.defaultContext
+    StatusService.signalStartedOrExit()
+    Logger.info("Application has started")
+  }
+
+  override def onStop() {
+    Logger.info("Application shutdown...")
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,15 @@ scalaVersion := "2.11.6"
 resolvers += "spray repo" at "http://repo.spray.io"
 
 libraryDependencies ++= Seq(
-  "org.apache.commons"   %  "commons-compress" % "1.8.1",
-  "commons-io"           %  "commons-io"       % "2.4",
-  "org.webjars"          %  "foundation"       % "5.5.1",
-  "com.googlecode.kiama" %% "kiama"            % "1.8.0",
-  "com.typesafe.play"    %% "play-doc"         % "1.1.0",
-  "io.spray"             %% "spray-caching"    % "1.3.3",
-  "org.scalatest"        %% "scalatest"        % "2.2.4" % "test",
-  "org.scalatestplus"    %% "play"             % "1.2.0" % "test",
+  "org.apache.commons"    %  "commons-compress" % "1.8.1",
+  "commons-io"            %  "commons-io"       % "2.4",
+  "org.webjars"           %  "foundation"       % "5.5.1",
+  "com.googlecode.kiama"  %% "kiama"            % "1.8.0",
+  "com.typesafe.conductr" %% "play-conductr-bundle-lib" % "0.6.1",
+  "com.typesafe.play"     %% "play-doc"         % "1.1.0",
+  "io.spray"              %% "spray-caching"    % "1.3.3",
+  "org.scalatest"         %% "scalatest"        % "2.2.4" % "test",
+  "org.scalatestplus"     %% "play"             % "1.2.0" % "test",
   ws
 )
 
@@ -33,4 +34,15 @@ StylusKeys.compress in Assets := false
 
 // Project/module declarations
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, SbtTypesafeConductR)
+
+// ConductR
+
+import ByteConversions._
+
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 50.MiB
+BundleKeys.roles := Set("web-doc")
+BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", 0, Set(URI("http://:9000"))))
+BundleKeys.startCommand += "-Dhttp.port=$WEBDOC_BIND_PORT -Dhttp.address=$WEBDOC_BIND_IP"

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,15 @@ scalaVersion := "2.11.6"
 resolvers += "spray repo" at "http://repo.spray.io"
 
 libraryDependencies ++= Seq(
-  "org.apache.commons"   %  "commons-compress" % "1.8.1",
-  "commons-io"           %  "commons-io"       % "2.4",
-  "org.webjars"          %  "foundation"       % "5.5.1",
-  "com.googlecode.kiama" %% "kiama"            % "1.8.0",
-  "com.typesafe.play"    %% "play-doc"         % "1.1.0",
-  "io.spray"             %% "spray-caching"    % "1.3.3",
-  "org.scalatest"        %% "scalatest"        % "2.2.4" % "test",
-  "org.scalatestplus"    %% "play"             % "1.2.0" % "test",
+  "org.apache.commons"    %  "commons-compress" 		% "1.8.1",
+  "commons-io"            %  "commons-io"       		% "2.4",
+  "org.webjars"           %  "foundation"       		% "5.5.1",
+  "com.googlecode.kiama"  %% "kiama"            		% "1.8.0",
+  "com.typesafe.conductr" %% "play-conductr-bundle-lib" % "0.6.1",
+  "com.typesafe.play"     %% "play-doc"         		% "1.1.0",
+  "io.spray"              %% "spray-caching"    		% "1.3.3",
+  "org.scalatest"         %% "scalatest"        		% "2.2.4" % "test",
+  "org.scalatestplus"     %% "play"             		% "1.2.0" % "test",
   ws
 )
 
@@ -33,4 +34,15 @@ StylusKeys.compress in Assets := false
 
 // Project/module declarations
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, SbtTypesafeConductR)
+
+// ConductR
+
+import ByteConversions._
+
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 50.MiB
+BundleKeys.roles := Set("web-doc")
+BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", 0, Set(URI("http://conductr.typesafe.com"))))
+BundleKeys.startCommand += "-Dhttp.port=$WEBDOC_BIND_PORT -Dhttp.address=$WEBDOC_BIND_IP"

--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,6 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 50.MiB
 BundleKeys.roles := Set("web-doc")
-<<<<<<< HEAD
+
 BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", 0, Set(URI("http://conductr.typesafe.com"))))
-=======
-BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", 0, Set(URI("http://:9000"))))
->>>>>>> 41bac5ed5623041f3b6a9a31e9ac9226b8f677be
 BundleKeys.startCommand += "-Dhttp.port=$WEBDOC_BIND_PORT -Dhttp.address=$WEBDOC_BIND_IP"

--- a/conf/play.plugins
+++ b/conf/play.plugins
@@ -1,0 +1,1 @@
+10001:plugins.ConductrPlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
+resolvers ++= Seq(Resolver.bintrayRepo("akka-contrib-extra", "maven"))
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M3")
@@ -16,3 +16,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.0.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
+
+// conductR
+addSbtPlugin("com.typesafe.conductr" % "sbt-typesafe-conductr" % "0.27.0")


### PR DESCRIPTION
Test deployed at: https://milo.typesafe.com/conductr/
