### PR TITLE
Update the production location for the conductr doc

### DIFF
--- a/app/modules/ConductRModule.scala
+++ b/app/modules/ConductRModule.scala
@@ -15,7 +15,7 @@ object ConductRModule {
 
     private val renderer =
       actorSystem.actorOf(DocRenderer.props(
-        new URI("https://github.com/huntc/conductr-doc/archive/master.zip"),
+        new URI("https://github.com/typesafehub/conductr-doc/archive/master.zip"),
         removeRootSegment = true,
         Paths.get("src/main/play-doc"),
         "1.0.x",

--- a/build.sbt
+++ b/build.sbt
@@ -9,15 +9,15 @@ scalaVersion := "2.11.6"
 resolvers += "spray repo" at "http://repo.spray.io"
 
 libraryDependencies ++= Seq(
-  "org.apache.commons"    %  "commons-compress" 		% "1.8.1",
-  "commons-io"            %  "commons-io"       		% "2.4",
-  "org.webjars"           %  "foundation"       		% "5.5.1",
-  "com.googlecode.kiama"  %% "kiama"            		% "1.8.0",
+  "org.apache.commons"    %  "commons-compress" 		    % "1.8.1",
+  "commons-io"            %  "commons-io"       		    % "2.4",
+  "org.webjars"           %  "foundation"       	     	% "5.5.1",
+  "com.googlecode.kiama"  %% "kiama"            		    % "1.8.0",
   "com.typesafe.conductr" %% "play-conductr-bundle-lib"	% "0.6.1",
-  "com.typesafe.play"     %% "play-doc"         		% "1.1.0",
-  "io.spray"              %% "spray-caching"    		% "1.3.3",
-  "org.scalatest"         %% "scalatest"        		% "2.2.4" % "test",
-  "org.scalatestplus"     %% "play"             		% "1.2.0" % "test",
+  "com.typesafe.play"     %% "play-doc"         		    % "1.1.0",
+  "io.spray"              %% "spray-caching"    		    % "1.3.3",
+  "org.scalatest"         %% "scalatest"        		    % "2.2.4" % "test",
+  "org.scalatestplus"     %% "play"             		    % "1.2.0" % "test",
   ws
 )
 
@@ -34,7 +34,7 @@ StylusKeys.compress in Assets := false
 
 // Project/module declarations
 
-lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, SbtTypesafeConductR)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, ConductRPlugin)
 
 // ConductR
 
@@ -45,5 +45,5 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 50.MiB
 BundleKeys.roles := Set("web-doc")
 
-BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", 0, Set(URI("http://conductr.typesafe.com"))))
+BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", services = Set(URI("http://conductr.typesafe.com"))))
 BundleKeys.startCommand += "-Dhttp.port=$WEBDOC_BIND_PORT -Dhttp.address=$WEBDOC_BIND_IP"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,4 +23,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
 addSbtPlugin("default" % "sbt-sass" % "0.1.9")
 
 // conductR
-addSbtPlugin("com.typesafe.conductr" % "sbt-typesafe-conductr" % "0.27.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "0.28.0")


### PR DESCRIPTION
Previously specified to retrieve doco from huntc instead of typesafehub. Now corrected.

Also, updated a few other libs with exception to play-conductr-bundle-lib 0.7.0. The reason the latter hasn't been updated is due to a problem with Play and having recently upgraded its Ning client. Will raise an issue on Play.
