### PR TITLE
Doc renderer cluster

### DIFF
--- a/app/modules/ConductRModule.scala
+++ b/app/modules/ConductRModule.scala
@@ -6,12 +6,15 @@ import javax.inject.{Provider, Inject, Singleton}
 
 import akka.actor.{ActorRef, ActorSystem}
 import doc.DocRenderer
+import play.api.{Configuration, Environment}
+import play.api.inject.Module
 import play.api.libs.ws.WSClient
 
 object ConductRModule {
 
   @Singleton
-  class ConductRDocRendererProvider @Inject()(actorSystem: ActorSystem, wsClient: WSClient) extends Provider[ActorRef] {
+  class ConductRDocRendererProvider @Inject()(actorSystem: ActorSystem, wsClient: WSClient)
+    extends Provider[ActorRef] {
 
     private val renderer =
       actorSystem.actorOf(DocRenderer.props(
@@ -22,6 +25,14 @@ object ConductRModule {
         wsClient), "conductr-doc-renderer")
 
     override def get = renderer
-
   }
+}
+
+class ConductRModule extends Module {
+  import ConductRModule._
+
+  def bindings(environment: Environment,
+               configuration: Configuration) = Seq(
+    bind[ActorRef].qualifiedWith("ConductRDocRenderer").toProvider[ConductRDocRendererProvider]
+  )
 }

--- a/app/modules/CustomApplicationLoader.scala
+++ b/app/modules/CustomApplicationLoader.scala
@@ -1,0 +1,15 @@
+package modules
+
+import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
+import com.typesafe.conductr.bundlelib.play.{ Env => PlayEnv }
+import play.api.inject.guice.GuiceApplicationLoader
+import play.api.{Configuration, Application, ApplicationLoader}
+
+class CustomApplicationLoader extends ApplicationLoader {
+  def load(context: ApplicationLoader.Context): Application = {
+    val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
+    val newConfig = context.initialConfiguration ++ conductRConfig
+    val newContext = context.copy(initialConfiguration = newConfig)
+    (new GuiceApplicationLoader).load(newContext)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,19 @@ version := "1.0-SNAPSHOT"
 
 scalaVersion := "2.11.6"
 
-resolvers += "spray repo" at "http://repo.spray.io"
+resolvers ++= Seq(
+  "spray repo" at "http://repo.spray.io",
+  "patriknw at bintray" at "http://dl.bintray.com/patriknw/maven"
+)
 
 libraryDependencies ++= Seq(
+  "com.github.patriknw"   %% "akka-data-replication"    % "0.11",
+  "com.typesafe.conductr" %% "akka-conductr-bundle-lib"	% "0.8.0",
   "org.apache.commons"    %  "commons-compress" 		    % "1.8.1",
   "commons-io"            %  "commons-io"       		    % "2.4",
   "org.webjars"           %  "foundation"       	     	% "5.5.1",
   "com.googlecode.kiama"  %% "kiama"            		    % "1.8.0",
-  "com.typesafe.conductr" %% "play-conductr-bundle-lib"	% "0.6.1",
+  "com.typesafe.conductr" %% "play-conductr-bundle-lib"	% "0.9.0-4158e00ea986c1b619378d5ba8bc364d34acfc0d",
   "com.typesafe.play"     %% "play-doc"         		    % "1.1.0",
   "io.spray"              %% "spray-caching"    		    % "1.3.3",
   "org.scalatest"         %% "scalatest"        		    % "2.2.4" % "test",
@@ -45,5 +50,10 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 50.MiB
 BundleKeys.roles := Set("web-doc")
 
-BundleKeys.endpoints := Map("webdoc" -> Endpoint("http", services = Set(URI("http://conductr.typesafe.com"))))
-BundleKeys.startCommand += "-Dhttp.port=$WEBDOC_BIND_PORT -Dhttp.address=$WEBDOC_BIND_IP"
+BundleKeys.system := "doc-renderer-cluster-1.0"
+
+BundleKeys.endpoints := Map(
+  "akka-remote" -> Endpoint("tcp"),
+  "web" -> Endpoint("http", services = Set(URI("http://conductr.typesafe.com")))
+)
+BundleKeys.startCommand += "-Dhttp.port=$WEB_BIND_PORT -Dhttp.address=$WEB_BIND_IP"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -24,9 +24,16 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
+# The time to wait for a resource to be rendered
 doc.renderer.timeout = 1.minute
 
 # Alias the following hosts for the purposes of routing.
 app.host-aliases = {
   localhost: conductr
 }
+
+# Render cluster configuration
+akka.actor.provider = akka.cluster.ClusterActorRefProvider
+
+play.application.loader = "modules.CustomApplicationLoader"
+play.modules.enabled += "modules.ConductRModule"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,4 +23,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
 addSbtPlugin("default" % "sbt-sass" % "0.1.9")
 
 // conductR
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "0.28.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "0.30.0")


### PR DESCRIPTION
As well as some general improvements for Play 2.4, this PR transforms play-doc into a clustered application that propagates the receipt of webhook events across all instances of play-doc.
