### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,31 +19,27 @@ libraryDependencies ++= Seq(
   "commons-io"            %  "commons-io"       		      % "2.4",
   "org.webjars"           %  "foundation"       	     	  % "5.5.1",
   "com.googlecode.kiama"  %% "kiama"            		      % "1.8.0",
-  "com.typesafe.conductr" %% "play24-conductr-bundle-lib"	% "0.13.0",
+  "com.typesafe.conductr" %% "play24-conductr-bundle-lib"	% "1.0.0",
   "com.typesafe.play"     %% "play-doc"         		      % "1.1.0",
   "io.spray"              %% "spray-caching"    		      % "1.3.3",
   "org.scalatest"         %% "scalatest"        		      % "2.2.4" % "test",
-  "org.scalatestplus"     %% "play"             		      % "1.2.0" % "test",
+  "org.scalatestplus"     %% "play"             		      % "1.4.0-M3" % "test",
   ws
 )
 
 // Play
-
 routesGenerator := InjectedRoutesGenerator
 
 // sbt-web
-
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
 sassOptions in Assets ++= Seq("--compass", "-r", "compass")
 StylusKeys.useNib in Assets := true
 StylusKeys.compress in Assets := false
 
 // Project/module declarations
-
 lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, ConductRPlugin)
 
 // ConductR
-
 import ByteConversions._
 
 BundleKeys.nrOfCpus := 1.0

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,16 +13,7 @@ play.crypto.secret=${?APPLICATION_SECRET}
 
 # The application languages
 # ~~~~~
-play.i18n.langs="en"
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
+play.i18n.langs=["en"]
 
 # The time to wait for a resource to be rendered
 doc.renderer.timeout = 1.minute

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,0 +1,26 @@
+<configuration>
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>logs/application.log</file>
+    <encoder>
+      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILE" />
+  </root>
+
+</configuration>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,24 +3,12 @@ resolvers ++= Seq(
   Resolver.url("GitHub repository", url("http://shaggyyeti.github.io/releases"))(Resolver.ivyStylePatterns)
 )
 
-// The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-RC1")
+// Play plugin
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
 
-// web plugins
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-jshint" % "1.0.3")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.7")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.0.2")
-
+// Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
-
 addSbtPlugin("default" % "sbt-sass" % "0.1.9")
 
-// conductR
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "0.34.0")
+// ConductR
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")


### PR DESCRIPTION
Upgrade libraries:
- Play: 2.4.2
- ScalaTest + Play: 1.4.0-M3
- Play ConductR Bundle Lib: 1.0.0
- SBT ConductR: 1.0.0

Also removed the logging information in the `application.conf` and instead added a `logback.xml` (needed for Play 2.4).
