### PR TITLE
Changes to publish the 1.1 branch separately

### DIFF
--- a/app/modules/ConductRDocRendererModule.scala
+++ b/app/modules/ConductRDocRendererModule.scala
@@ -41,8 +41,17 @@ object ConductRDocRendererModule {
     extends ConductRDocRendererProvider(
       actorSystem,
       wsClient,
-      new URI("https://github.com/typesafehub/conductr-doc/archive/master.zip"),
+      new URI("https://github.com/typesafehub/conductr-doc/archive/1.1.zip"),
       "1.1.x"
+    )
+
+  @Singleton
+  class ConductRDocRendererProvider12 @Inject()(actorSystem: ActorSystem, wsClient: WSClient)
+    extends ConductRDocRendererProvider(
+      actorSystem,
+      wsClient,
+      new URI("https://github.com/typesafehub/conductr-doc/archive/master.zip"),
+      "1.2.x"
     )
 }
 
@@ -52,6 +61,7 @@ class ConductRDocRendererModule extends Module {
   def bindings(environment: Environment,
                configuration: Configuration) = Seq(
     bind[ActorRef].qualifiedWith("ConductRDocRenderer10").toProvider[ConductRDocRendererProvider10],
-    bind[ActorRef].qualifiedWith("ConductRDocRenderer11").toProvider[ConductRDocRendererProvider11]
+    bind[ActorRef].qualifiedWith("ConductRDocRenderer11").toProvider[ConductRDocRendererProvider11],
+    bind[ActorRef].qualifiedWith("ConductRDocRenderer12").toProvider[ConductRDocRendererProvider12]
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 // General
 
 name := "project-doc"
-
 version := "1.0-SNAPSHOT"
-
 scalaVersion := "2.11.7"
+
+licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 resolvers ++= Seq(
   "spray repo"          at "http://repo.spray.io",
@@ -37,9 +37,6 @@ sassOptions in Assets ++= Seq("--compass", "-r", "compass")
 StylusKeys.useNib in Assets := true
 StylusKeys.compress in Assets := false
 
-// Project/module declarations
-lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, ConductRPlugin)
-
 // ConductR
 import ByteConversions._
 
@@ -55,3 +52,13 @@ BundleKeys.endpoints := Map(
   "web" -> Endpoint("http", services = Set(URI("http://conductr.typesafe.com")))
 )
 BundleKeys.startCommand += "-Dhttp.port=$WEB_BIND_PORT -Dhttp.address=$WEB_BIND_IP"
+
+// Bundle publishing configuration
+
+inConfig(Bundle)(Seq(
+  bintrayVcsUrl := Some("https://github.com/typesafehub/project-doc"),
+  bintrayOrganization := Some("typesafe")
+))
+
+// Project/module declarations
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, ConductRPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,8 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
-addSbtPlugin("default" % "sbt-sass" % "0.1.9")
+addSbtPlugin("default"          % "sbt-sass"   % "0.1.9")
 
 // ConductR
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr"         % "1.2.1")
+addSbtPlugin("com.typesafe.sbt"      % "sbt-bintray-bundle"   % "1.0.1")


### PR DESCRIPTION
Also, improved the reporting of an unauthorised update so that tests are easier to change.

Finally, included bintray publishing info so that project-doc is easily published as a bundle. As such, loading project-doc should now be as easy as:

```
conduct load project-doc
```
