### PR TITLE
Increase HMAC buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ brew install node
 
 Also the project is using [sbt-sass](https://github.com/ShaggyYeti/sbt-sass) to compile Sass files to CSS. This plugin needs the Saas compiler and compass to work:
 ```
-gem install sass
-gem install compass
+sudo gem install sass
+sudo gem install compass
 ```
 
 Afterwards you can start the Play application locally:

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 object Application {
 
   private[controllers] object MacBodyParser {
-    def apply(hmacHeader: String, secret: SecretKeySpec, algorithm: String, maxBodySize: Int = 8192) =
+    def apply(hmacHeader: String, secret: SecretKeySpec, algorithm: String, maxBodySize: Int = 65536) =
       new MacBodyParser(hmacHeader, secret, algorithm, maxBodySize)
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 resolvers ++= Seq(
   Resolver.bintrayRepo("akka-contrib-extra", "maven"),
-  Resolver.url("GitHub repository", url("http://shaggyyeti.github.io/releases"))(Resolver.ivyStylePatterns)
+  Resolver.url("GitHub repository", url("http://shaggyyeti.github.io/releases"))(Resolver.ivyStylePatterns),
+  "Typesafe Repository" at "https://repo.typesafe.com/typesafe/maven-releases"
 )
 
 // Play plugin

--- a/test/doc/DocRendererSpec.scala
+++ b/test/doc/DocRendererSpec.scala
@@ -1,7 +1,5 @@
 package doc
 
-import java.io.File
-
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 import play.api.libs.iteratee.Enumerator
@@ -13,15 +11,16 @@ class DocRendererSpec extends WordSpecLike with Matchers {
 
   "DocRenderer" should {
     "Receive a zipped stream, decompress it and write it to a file" in {
-      val zipFile = getClass.getClassLoader.getResource("conductr-doc.zip")
-      val input = Enumerator.fromStream(zipFile.openStream())
-      val result = DocRenderer.unzip(input, removeRootSegment = true)
+      val f = fixtures
+      import f._
       val docDir = Await.result(result, 5.seconds)
       docDir.resolve("src").toFile.exists() shouldBe true
     }
 
     "Form html from the toc files of the zipped stream" in {
-      val docDir = new File(getClass.getClassLoader.getResource("conductr-doc").toURI).toPath
+      val f = fixtures
+      import f._
+      val docDir = Await.result(result, 5.seconds)
       val html = DocRenderer.aggregateToc(docDir.resolve("src/main/play-doc"), "/docs")
       html.toString() shouldBe
         """<ul>
@@ -35,5 +34,11 @@ class DocRendererSpec extends WordSpecLike with Matchers {
           |    </li>
           |</ul>""".stripMargin
     }
+  }
+
+  def fixtures = new {
+    val zipFile = getClass.getClassLoader.getResource("conductr-doc.zip")
+    val input = Enumerator.fromStream(zipFile.openStream())
+    val result = DocRenderer.unzip(input, removeRootSegment = true)
   }
 }


### PR DESCRIPTION
We had a max buffer size of 8KiB. I have now increased this to 64KiB as Github passed us a 10KiB webhook. We have to choose a limit as the JDK likes to work with an array. :-)

Nice that the proggy behaved well under this condition though - and continued to serve docs despite failing to receive the notifications of new ones.

Fixes up a flaw in our tests too - one test depended on another in terms of creating a doc folder somewhere.
