### PR TITLE
Styling improvements

### DIFF
--- a/app/assets/css/modules/_tables.sass
+++ b/app/assets/css/modules/_tables.sass
@@ -6,3 +6,5 @@ table
         color: $white
     tr td
         color: $lb-slate
+    td
+        vertical-align: top

--- a/app/assets/css/modules/_type.sass
+++ b/app/assets/css/modules/_type.sass
@@ -25,7 +25,7 @@ h1
         margin-top: 0
 h2
     font-family: inherit
-    font-size: 1.8em
+    font-size: 2em
     margin-bottom: 0.2em
     margin-top: 1.3em
     font-weight: 500
@@ -34,7 +34,7 @@ h2
         margin-top: 0
 h3, .panel h3
     font-family: inherit
-    font-size: 1.125em
+    font-size: 1.4em
     font-weight: 700
     margin-top: 1.3em
     color: $lb-slate-dkr
@@ -42,7 +42,7 @@ h3, .panel h3
         margin-top: 0
 h4
     font-family: inherit
-    font-size: 1em
+    font-size: 1.125em
     font-weight: 700
     margin-top: 1.3em
     color: $lb-slate-dkr
@@ -51,6 +51,7 @@ h4
 h5
     font-family: inherit
     font-size: 1em
+    font-weight: 700
     margin-top: 1.3em
     color: $lb-slate-dkr
     &:first-child
@@ -58,6 +59,7 @@ h5
 h6
     font-family: inherit
     font-size: 1em
+    font-style: italic
     margin-top: 1.3em
     color: $lb-slate-dkr
     &:first-child


### PR DESCRIPTION
- Aligns table cells vertically to the 'top' which makes rows more readable if one column has a short text and another column has wrapping text
- Changes the headline font-size, font-weight and font-style slightly. In particular h5 and h6 headlines can be now distinguished to normal p text.

Tested the new styles locally based on the PR https://github.com/typesafehub/conductr-doc/pull/207. The page `src/main/play-doc/operation/DynamicProxyConfiguration.md` contains headlines from `<h1>` to `<h6>`.
