### PR TITLE
Reflect ConductR 2.0

### DIFF
--- a/app/modules/ConductRDocRendererModule.scala
+++ b/app/modules/ConductRDocRendererModule.scala
@@ -46,12 +46,12 @@ object ConductRDocRendererModule {
     )
 
   @Singleton
-  class ConductRDocRendererProvider12 @Inject()(actorSystem: ActorSystem, wsClient: WSClient)
+  class ConductRDocRendererProvider20 @Inject()(actorSystem: ActorSystem, wsClient: WSClient)
     extends ConductRDocRendererProvider(
       actorSystem,
       wsClient,
       new URI("https://github.com/typesafehub/conductr-doc/archive/master.zip"),
-      "1.2.x"
+      "2.0.x"
     )
 }
 
@@ -62,6 +62,6 @@ class ConductRDocRendererModule extends Module {
                configuration: Configuration) = Seq(
     bind[ActorRef].qualifiedWith("ConductRDocRenderer10").toProvider[ConductRDocRendererProvider10],
     bind[ActorRef].qualifiedWith("ConductRDocRenderer11").toProvider[ConductRDocRendererProvider11],
-    bind[ActorRef].qualifiedWith("ConductRDocRenderer12").toProvider[ConductRDocRendererProvider12]
+    bind[ActorRef].qualifiedWith("ConductRDocRenderer20").toProvider[ConductRDocRendererProvider20]
   )
 }

--- a/app/views/conductr/index.scala.html
+++ b/app/views/conductr/index.scala.html
@@ -5,23 +5,30 @@
     <div class="fw-wrapper page-content">
         <div class="row">
             <div class="small-12">
-                <h1>Today’s demands on Operations are simply not met by yesterday’s software architectures and technologies</h1>
-                <p>ConductR is a solution for managing Lightbend Reactive Platform applications across a cluster of machines. ConductR is reactive from the ground up thus enabling operations to provide the resiliency required to unleash the full benefits of the Lightbend Reactive Platform in their organization.</p>
+                <h1>Managing microservices with the "batteries included"</h1>
 
-                <p>ConductR moves beyond simply running multiple instances of the services that are your applications. With ConductR, we deploy applications, in the form of archives of components together with their configuration metadata, to the cluster. ConductR is a deployment target for the next generation of applications as we continue the progression up the infrastructure stack from bare hardware, to virtual machines, to IaaS and now clusters.</p>
+                <p>Distributed systems are required for microservices and they can benefit a business greatly given their potential
+                    for increased availability.
+                    However writing distributed systems is hard and managing them is even harder.
+                    When you can no longer name your machines or count them on one hand then you need something to help you.
 
-                <p>For teams using tools like Chef, Puppet, Ansible and Terraform, ConductR simplifies the task of clustering Reactive Platform applications. Without ConductR, the provisioning and configuration playbooks also install and configure applications as part of provisioning cluster nodes. With ConductR, this layer now only needs to install and configure ConductR. The configuration and management of the applications running of the cluster is treated as the separate concern that it is.</p>
+                <p>ConductR is a "batteries included" approach to managing distributed systems.
+                No more cobbling together of service gateways, service locators, consolidated logging, monitoring and so forth.
+                All of these essential items and more are included with ConductR. In fact we want ConductR to be to operations
+                what Play and Lagom are to developers; we want operations to be productive so that they can concentrate on keeping
+                their business customers happy.
 
-                <p>ConductR’s design was influenced by Mesos by adopting its notion of resource requests and offers, and support for Docker containers for example. ConductR runs stand-alone and is also planned to be available as a Mesos framework later this year. ConductR is also a refreshing alternative to using Apache ZooKeeper for service discovery in your applications and services.</p>
+                <p>ConductR is also the easiest way to manage Akka cluster based applications, and laser-focused on ensuring that
+                    Lightbend Reactive Platform applications can be managed with ease. ConductR guides you regarding distributed
+                    concerns when embarking on developing a project; not as an after-thought when you near that release deadline.
 
-                <img src="@routes.Assets.at("images/svg/conductR-and-reactive-system-architecture.svg")">
+                <p>Please refer to the <a href="https://www.lightbend.com/product/conductr/developer">getting started page</a>
+                if you simply want to download ConductR and have it run on your local machine for non-production purposes. Otherwise
+                head on over to the <a href="@routes.Application.renderDocsHome("")">documentation</a> in order to find out
+                all that you need to know.
 
-                <p>ConductR is light-weight and highly resilient. Each node runs the ConductR process, a proxy (HAproxy) and conductr-haproxy; a reactive configuration process. This combination enables any node in the cluster to proxy requests for any service endpoint of the cluster leaving no single point of failure. ConductR leverages Akka clustering, data replication, FSM (Finite State Machine), reactive streams, CRDTs and more to provide the must have features such as consolidated logging, service discovery and rolling upgrades.</p>
-
-                <p>Our goal is that ConductR becomes known to the operator in a similar way to how Play is now known to the developer: a productive and joyful experience. Enjoy!</p>
-
-                <p>Warm regards,
-                <br/>The ConductR Team</p>
+                <p>Welcome to ConductR,
+                <br/>The Global ConductR Team
             </div>
         </div>
     </div>

--- a/build.sbt
+++ b/build.sbt
@@ -2,30 +2,25 @@
 
 name := "project-doc"
 version := "1.0-SNAPSHOT"
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-resolvers ++= Seq(
-  "spray repo"          at "http://repo.spray.io",
-  "patriknw at bintray" at "http://dl.bintray.com/patriknw/maven",
-  "typesafe-releases"   at "http://repo.typesafe.com/typesafe/maven-releases",
-  Resolver.bintrayRepo("typesafe", "maven-releases")
-)
+resolvers += "spray repo" at "http://repo.spray.io"
 
 libraryDependencies ++= Seq(
-  "com.github.patriknw"   %% "akka-data-replication"      % "0.11",
-  "org.apache.commons"    %  "commons-compress" 		      % "1.8.1",
-  "commons-io"            %  "commons-io"       		      % "2.4",
-  "org.webjars"           %  "foundation"       	     	  % "5.5.1",
-  "org.webjars"           %  "prettify"                   % "4-Mar-2013",
-  "com.googlecode.kiama"  %% "kiama"            		      % "1.8.0",
-  "com.typesafe.conductr" %% "play24-conductr-bundle-lib"	% "1.0.1",
-  "com.typesafe.play"     %% "play-doc"         		      % "1.2.3",
-  "io.spray"              %% "spray-caching"    		      % "1.3.3",
-  "com.typesafe.akka"     %% "akka-testkit"               % "2.3.12",
-  "org.scalatest"         %% "scalatest"        		      % "2.2.4" % "test",
-  "org.scalatestplus"     %% "play"             		      % "1.4.0-M3" % "test"
+  "com.typesafe.akka"      %% "akka-distributed-data-experimental" % "2.4.7",
+  "org.apache.commons"     %  "commons-compress" 		               % "1.11",
+  "commons-io"             %  "commons-io"       		               % "2.5",
+  "org.webjars"            %  "foundation"       	     	           % "5.5.1",
+  "org.webjars"            %  "prettify"                           % "4-Mar-2013",
+  "com.googlecode.kiama"   %% "kiama"            		               % "1.8.0",
+  "com.typesafe.conductr"  %% "play25-conductr-bundle-lib"	       % "1.4.7",
+  "com.typesafe.play"      %% "play-doc"         		               % "1.6.0",
+  "io.spray"               %% "spray-caching"    		               % "1.3.3",
+  "com.typesafe.akka"      %% "akka-testkit"                       % "2.3.12",
+  "org.scalatest"          %% "scalatest"        		               % "2.2.4" % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play"                 % "1.5.1" % "test"
 )
 
 // Play
@@ -40,18 +35,23 @@ StylusKeys.compress in Assets := false
 // ConductR
 import ByteConversions._
 
+javaOptions in Universal := Seq(
+  "-J-Xmx64m",
+  "-J-Xms64m"
+)
+
 BundleKeys.nrOfCpus := 1.0
-BundleKeys.memory := 64.MiB
+BundleKeys.memory := 128.MiB
 BundleKeys.diskSpace := 50.MiB
 BundleKeys.roles := Set("web-doc")
 
-BundleKeys.system := "doc-renderer-cluster-1"
+BundleKeys.system := "doc-renderer-cluster"
+BundleKeys.systemVersion := "2"
 
 BundleKeys.endpoints := Map(
   "akka-remote" -> Endpoint("tcp"),
   "web" -> Endpoint("http", services = Set(URI("http://conductr.lightbend.com")))
 )
-BundleKeys.startCommand += "-Dhttp.port=$WEB_BIND_PORT -Dhttp.address=$WEB_BIND_IP"
 
 // Bundle publishing configuration
 
@@ -61,4 +61,4 @@ inConfig(Bundle)(Seq(
 ))
 
 // Project/module declarations
-lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala, ConductRPlugin)
+lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -30,8 +30,4 @@ akka {
   cluster.auto-down-unreachable-after = 30s
 }
 
-play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-
-play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule"
-
 play.modules.enabled += "modules.ConductRDocRendererModule"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ resolvers ++= Seq(
 )
 
 // Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.3")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
 addSbtPlugin("default"          % "sbt-sass"   % "0.1.9")
 
 // ConductR
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr"         % "1.2.1")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-bintray-bundle"   % "1.0.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr"        % "2.1.6")
+addSbtPlugin("com.typesafe.sbt"       % "sbt-bintray-bundle"  % "1.0.2")


### PR DESCRIPTION
We now refer what was ConductR 1.2 as 2.0 given the major changes in its topology in particular i.e. the distinction between core and agent.

I've also updated the main page's copy to reflect the why, what and how of ConductR.

Finally, I've updated the releases of everything. In particular I've migrated the code from Play 2.3 to Play 2.5, along with lots of updates to Akka 2.4, distributed data and so forth. This had to be done at some point. We could go further here in terms of retiring iteratees altogether, but that can be for another day. These updates take care of the bulk of modernisation and will last for some time into the future.
