### PR TITLE
Make 2.0 the default doc

### DIFF
--- a/app/assets/css/modules/_base.sass
+++ b/app/assets/css/modules/_base.sass
@@ -231,7 +231,6 @@ body
             display: inline-block
             font-weight: 500
         .versionNumber
-            float: right
     #toc
         h3, h3 a
             color: $lb-slate-dkr

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -88,6 +88,7 @@ class Application @Inject() (
                               @Named("ConductRDocRenderer10") conductrDocRenderer10: ActorRef,
                               @Named("ConductRDocRenderer11") conductrDocRenderer11: ActorRef,
                               @Named("ConductRDocRenderer20") conductrDocRenderer20: ActorRef,
+                              @Named("ConductRDocRenderer21") conductrDocRenderer21: ActorRef,
                               settings: Settings) extends Controller {
 
   import Application._
@@ -157,10 +158,11 @@ class Application @Inject() (
 
   private val docRenderers = Map(
     "conductr" -> Map(
-      "" -> conductrDocRenderer11,
+      "" -> conductrDocRenderer20,
       "1.0.x" -> conductrDocRenderer10,
       "1.1.x" -> conductrDocRenderer11,
-      "2.0.x" -> conductrDocRenderer20
+      "2.0.x" -> conductrDocRenderer20,
+      "2.1.x" -> conductrDocRenderer21
     )
   )
 
@@ -168,7 +170,8 @@ class Application @Inject() (
     "conductr" -> Map(
       "1.0" -> "1.0.x",
       "1.1" -> "1.1.x",
-      "master" -> "2.0.x"
+      "2.0" -> "2.0.x",
+      "master" -> "2.1.x"
     )
   )
 

--- a/app/doc/HtmlPrettyPrinter.scala
+++ b/app/doc/HtmlPrettyPrinter.scala
@@ -27,6 +27,12 @@ object HtmlPrettyPrinter extends PrettyPrinter {
   def a(name: String, ref: URI): Doc =
     angles("a" <+> "href" <> "=" <> dquotes(ref.toString)) <> name <> angles(forwslash <> "a")
 
+  def select(d: Doc, clazz: Option[String] = None, onChange: String): Doc =
+    angles("select" <+> "onchange" <> "=" <> dquotes(onChange) <> parseClass(clazz)) <> d <> angles(forwslash <> "select")
+
+  def option(d: Doc, value: String, selected: Boolean): Doc =
+    angles("option" <+> "value" <> "=" <> dquotes(value) <+> (if (selected) "selected" else empty)) <> d <> angles(forwslash <> "option")
+
   def p(d: Doc): Doc =
     angles(s"p") <> d <> angles(forwslash <> s"p")
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -74,7 +74,7 @@
                             @mainNav(false)
                         </div>
                         <div class="small-12 medium-3 columns logo-copyright">
-                            &copy; 2016&nbsp;<a href="http://www.lightbend.com">@svg.companyColorReverse()</a>
+                            &copy; 2016,2017&nbsp;<a href="http://www.lightbend.com">@svg.companyColorReverse()</a>
                         </div>
                     </div>
                 </footer>

--- a/test/controllers/ApplicationSpec.scala
+++ b/test/controllers/ApplicationSpec.scala
@@ -111,7 +111,8 @@ class ApplicationSpec  extends WordSpecLike with Matchers with EitherValues {
 
       conductrDocRenderer10.expectMsg(DocRenderer.PropogateGetSite)
       conductrDocRenderer11.expectNoMsg(500.millis)
-      conductrDocRenderer12.expectNoMsg(500.millis)
+      conductrDocRenderer20.expectNoMsg(500.millis)
+      conductrDocRenderer21.expectNoMsg(500.millis)
 
       val request2 =
         FakeRequest("POST", "/")
@@ -131,7 +132,8 @@ class ApplicationSpec  extends WordSpecLike with Matchers with EitherValues {
 
       conductrDocRenderer11.expectMsg(DocRenderer.PropogateGetSite)
       conductrDocRenderer10.expectNoMsg(500.millis)
-      conductrDocRenderer12.expectNoMsg(500.millis)
+      conductrDocRenderer20.expectNoMsg(500.millis)
+      conductrDocRenderer21.expectNoMsg(500.millis)
 
       val request3 =
         FakeRequest("POST", "/")
@@ -150,7 +152,8 @@ class ApplicationSpec  extends WordSpecLike with Matchers with EitherValues {
 
       contentAsString(result3) shouldBe "Site update requested"
 
-      conductrDocRenderer12.expectMsg(DocRenderer.PropogateGetSite)
+      conductrDocRenderer21.expectNoMsg(500.millis)
+      conductrDocRenderer20.expectMsg(DocRenderer.PropogateGetSite)
       conductrDocRenderer11.expectNoMsg(500.millis)
       conductrDocRenderer10.expectNoMsg(500.millis)
     }
@@ -197,11 +200,12 @@ class ApplicationSpec  extends WordSpecLike with Matchers with EitherValues {
 
     val conductrDocRenderer10 = TestProbe()
     val conductrDocRenderer11 = TestProbe()
-    val conductrDocRenderer12 = TestProbe()
+    val conductrDocRenderer20 = TestProbe()
+    val conductrDocRenderer21 = TestProbe()
     val config = ConfigFactory.load()
     val settings = new Settings(Configuration(config))
 
-    val application = new Application(conductrDocRenderer10.ref, conductrDocRenderer11.ref, conductrDocRenderer12.ref, settings)
+    val application = new Application(conductrDocRenderer10.ref, conductrDocRenderer11.ref, conductrDocRenderer20.ref, conductrDocRenderer21.ref, settings)
   }
 
   private def withActorSystem[T](block: ActorSystem => T): T = {


### PR DESCRIPTION
...and also allow the doc to be selectable.

Deploy only when a 2.0 branch becomes available for ConductR i.e. when it is released.