### PR TITLE
Use prettify from master

### DIFF
--- a/app/views/conductr/body.scala.html
+++ b/app/views/conductr/body.scala.html
@@ -14,7 +14,7 @@
     </script>
 
     <!-- Code syntax highlighter -->
-    <script src="@routes.Assets.at("lib/prettify/run_prettify.js")"></script>
+    <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 
     <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
     <script type="text/javascript">

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ libraryDependencies ++= Seq(
   "org.apache.commons"     %  "commons-compress" 		               % "1.11",
   "commons-io"             %  "commons-io"       		               % "2.5",
   "org.webjars"            %  "foundation"       	     	           % "5.5.1",
-  "org.webjars"            %  "prettify"                           % "4-Mar-2013",
   "com.googlecode.kiama"   %% "kiama"            		               % "1.8.0",
   "com.typesafe.conductr"  %% "play25-conductr-bundle-lib"	       % "1.4.7",
   "com.typesafe.play"      %% "play-doc"         		               % "1.6.0",


### PR DESCRIPTION
Using `code-prettify` from `https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js` because the releases are not maintained yet, i.e. when using the latest release `4-Mar-2013` then a javascript error inside `run_prettify.js` is thrown.

This enabled code syntax highlighting which was previously broken.

Fixes 