### PR TITLE
Immediately release when publishing to Bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,8 @@ BundleKeys.endpoints := Map(
 
 inConfig(Bundle)(Seq(
   bintrayVcsUrl := Some("https://github.com/typesafehub/project-doc"),
-  bintrayOrganization := Some("typesafe")
+  bintrayOrganization := Some("typesafe"),
+  bintrayReleaseOnPublish := true
 ))
 
 // Project/module declarations


### PR DESCRIPTION
This is to allow CD pipeline setup for `project-doc`.